### PR TITLE
fixes issues

### DIFF
--- a/scripts/landing.js
+++ b/scripts/landing.js
@@ -8,9 +8,7 @@ var animatePoints = function() {
         points[index].style.msTransform = "scaleX(1) translateY(0)";
         points[index].style.WebkitTransform = "scaleX(1) translateY(0)";
                  };
-    for(var i = 0; i <= points.length; i++) {
+    for(var i = 0; i < points.length; i++) {
         revealPoint(i);
         }
 };
-             
-animatePoints();


### PR DESCRIPTION
# What is this?

So after re-reading the checkpoint, you do not want the `animatePoints()` call at the end. The error in the console was also calling the loop one too many times, looks it did matter. I was confusing checkpoint 9 with this checkpoint, my bad 😪
# Solution

Removes `animatePoints()`
Remove `=` in `<=`
